### PR TITLE
JogAmp JOGL 2.3.1 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
 		<dependency>
 			<groupId>org.jogamp.gluegen</groupId>
 			<artifactId>gluegen-rt-main</artifactId>
-			<version>2.0.2</version>
+			<version>2.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jogamp.jogl</groupId>
 			<artifactId>jogl-all-main</artifactId>
-			<version>2.0.2</version>
+			<version>2.3.1</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/quantum/Quantum.java
+++ b/src/main/java/quantum/Quantum.java
@@ -18,12 +18,12 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
-import javax.media.opengl.GL;
-import javax.media.opengl.GLAutoDrawable;
-import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLEventListener;
-import javax.media.opengl.GLProfile;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLCapabilities;
+import com.jogamp.opengl.GLEventListener;
+import com.jogamp.opengl.GLProfile;
+import com.jogamp.opengl.awt.GLCanvas;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
@@ -218,7 +218,7 @@ public strictfp class Quantum extends JFrame implements GLEventListener {
 
 	public void display (GLAutoDrawable drawable) {
 		synchronized (drawable) {
-			drawable.getGL().glViewport(0,  0, drawable.getWidth(), drawable.getHeight());
+			drawable.getGL().glViewport(0,  0, drawable.getSurfaceWidth(), drawable.getSurfaceHeight());
 			drawable.getGL().glClearColor(0, 0, 0, 1);
 			drawable.getGL().glClear(GL.GL_COLOR_BUFFER_BIT);
 

--- a/src/main/java/quantum/forms/CreateMenu.java
+++ b/src/main/java/quantum/forms/CreateMenu.java
@@ -11,7 +11,7 @@
 
 package quantum.forms;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/Editor.java
+++ b/src/main/java/quantum/forms/Editor.java
@@ -23,9 +23,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 

--- a/src/main/java/quantum/forms/JoinMenu.java
+++ b/src/main/java/quantum/forms/JoinMenu.java
@@ -16,7 +16,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/LobbyMenu.java
+++ b/src/main/java/quantum/forms/LobbyMenu.java
@@ -17,7 +17,7 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/LocalGame.java
+++ b/src/main/java/quantum/forms/LocalGame.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/LoginMenu.java
+++ b/src/main/java/quantum/forms/LoginMenu.java
@@ -11,7 +11,7 @@
 
 package quantum.forms;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/MapMenu.java
+++ b/src/main/java/quantum/forms/MapMenu.java
@@ -19,7 +19,7 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.util.HashMap;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/NetworkedGame.java
+++ b/src/main/java/quantum/forms/NetworkedGame.java
@@ -17,9 +17,9 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/Replay.java
+++ b/src/main/java/quantum/forms/Replay.java
@@ -18,7 +18,7 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.util.zip.GZIPInputStream;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/StartMenu.java
+++ b/src/main/java/quantum/forms/StartMenu.java
@@ -15,7 +15,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.util.zip.GZIPInputStream;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/Tutorial.java
+++ b/src/main/java/quantum/forms/Tutorial.java
@@ -11,7 +11,7 @@
 
 package quantum.forms;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/forms/UpdateMenu.java
+++ b/src/main/java/quantum/forms/UpdateMenu.java
@@ -13,7 +13,7 @@ package quantum.forms;
 
 import java.io.File;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.Quantum;
 import quantum.Quantum.DisplayListener;

--- a/src/main/java/quantum/game/Boid.java
+++ b/src/main/java/quantum/game/Boid.java
@@ -14,9 +14,9 @@ package quantum.game;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.math.Vector2D;
 

--- a/src/main/java/quantum/game/Creature.java
+++ b/src/main/java/quantum/game/Creature.java
@@ -14,9 +14,9 @@ package quantum.game;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Color;
 import quantum.math.Vector2D;

--- a/src/main/java/quantum/game/GameInterface.java
+++ b/src/main/java/quantum/game/GameInterface.java
@@ -20,10 +20,10 @@ import java.awt.event.MouseMotionListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Color;
 import quantum.gfx.Font;

--- a/src/main/java/quantum/game/GameLoop.java
+++ b/src/main/java/quantum/game/GameLoop.java
@@ -11,7 +11,7 @@
 
 package quantum.game;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Renderer;
 import quantum.net.Client;

--- a/src/main/java/quantum/game/GameObject.java
+++ b/src/main/java/quantum/game/GameObject.java
@@ -14,7 +14,7 @@ package quantum.game;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.math.Vector2D;
 

--- a/src/main/java/quantum/game/Planet.java
+++ b/src/main/java/quantum/game/Planet.java
@@ -20,9 +20,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Renderer;
 import quantum.math.Vector2D;

--- a/src/main/java/quantum/game/Simulation.java
+++ b/src/main/java/quantum/game/Simulation.java
@@ -24,9 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 import quantum.game.commands.ChainCommand;
 import quantum.game.commands.Command;

--- a/src/main/java/quantum/game/Tree.java
+++ b/src/main/java/quantum/game/Tree.java
@@ -14,10 +14,10 @@ package quantum.game;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Color;
 import quantum.gfx.Renderer;

--- a/src/main/java/quantum/gfx/Color.java
+++ b/src/main/java/quantum/gfx/Color.java
@@ -14,8 +14,8 @@ package quantum.gfx;
 import java.io.Serializable;
 import java.nio.FloatBuffer;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
 
 /** a simple rgba color class. colors are given in the range [0,1].
  * 

--- a/src/main/java/quantum/gfx/Font.java
+++ b/src/main/java/quantum/gfx/Font.java
@@ -18,9 +18,9 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 /** a simple font class for drawing system fonts as textured quads.
  * 

--- a/src/main/java/quantum/gfx/FrameBufferObject.java
+++ b/src/main/java/quantum/gfx/FrameBufferObject.java
@@ -11,9 +11,9 @@
 
 package quantum.gfx;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 import quantum.gfx.Texture;
 import quantum.utils.Log;

--- a/src/main/java/quantum/gfx/InterleavedVertexArray.java
+++ b/src/main/java/quantum/gfx/InterleavedVertexArray.java
@@ -13,9 +13,9 @@ package quantum.gfx;
 
 import java.nio.FloatBuffer;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 import com.jogamp.common.nio.Buffers;
 

--- a/src/main/java/quantum/gfx/Mesh.java
+++ b/src/main/java/quantum/gfx/Mesh.java
@@ -19,9 +19,9 @@ import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 import com.jogamp.common.nio.Buffers;
 

--- a/src/main/java/quantum/gfx/OrthoCamera.java
+++ b/src/main/java/quantum/gfx/OrthoCamera.java
@@ -21,10 +21,10 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.util.HashSet;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.game.GameInterface;
 import quantum.math.Bounds;

--- a/src/main/java/quantum/gfx/Renderer.java
+++ b/src/main/java/quantum/gfx/Renderer.java
@@ -14,10 +14,10 @@ package quantum.gfx;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.game.Constants;
 import quantum.game.Creature;
@@ -33,7 +33,7 @@ import quantum.utils.FileManager;
 import quantum.utils.Log;
 import quantum.utils.Timer;
 
-import com.jogamp.opengl.util.awt.Screenshot;
+import com.jogamp.opengl.util.awt.AWTGLReadBufferUtil;
 
 public class Renderer {
 	FrameBufferObject offscreen_fbo;
@@ -187,7 +187,8 @@ public class Renderer {
 			fbo.renderFullScreenQuad();
 			gl.glDisable(GL.GL_BLEND);
 			gl.glDepthMask(true);
-			BufferedImage img = Screenshot.readToBufferedImage(256, 256);
+			AWTGLReadBufferUtil screenshot = new AWTGLReadBufferUtil(canvas.getGLProfile(), false /* alpha */);
+			BufferedImage img = screenshot.readPixelsToBufferedImage(gl, 0, 0, 256, 256, true /* awtOrientation */);
 			screen_fbo.unbind();
 			return img;
 		} else {
@@ -200,7 +201,8 @@ public class Renderer {
 			renderPass(sim, null, canvas);
 			gl.glDepthMask(true);
 			GLContext.getCurrent().getGL().glViewport(old_dim[0], old_dim[1], old_dim[2], old_dim[3]);
-			BufferedImage img = Screenshot.readToBufferedImage(256, 256);
+			AWTGLReadBufferUtil screenshot = new AWTGLReadBufferUtil(canvas.getGLProfile(), false /* alpha */);
+			BufferedImage img = screenshot.readPixelsToBufferedImage(gl, 0, 0, 256, 256, true /* awtOrientation */);
 			gl.glClear(GL.GL_COLOR_BUFFER_BIT);
 
 			return img;

--- a/src/main/java/quantum/gfx/Shader.java
+++ b/src/main/java/quantum/gfx/Shader.java
@@ -15,14 +15,14 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 public class Shader {
-	int program = -1;
-	int vertex_shader = -1;
-	int fragment_shader = -1;
+	long program = -1;
+	long vertex_shader = -1;
+	long fragment_shader = -1;
 
 	public Shader (InputStream vertex_shader, InputStream fragment_shader) throws Exception {
 		String vs_string = vertex_shader == null ? null : "";
@@ -85,7 +85,7 @@ public class Shader {
 		if (status[0] != GL.GL_TRUE) throw new Exception("glsl: error linking shader program, " + getInfoLog(this.program));
 	}
 
-	public String getInfoLog (int object) {
+	public String getInfoLog (long object) {
 		String text = "";
 		GL2 gl = GLContext.getCurrent().getGL().getGL2();
 

--- a/src/main/java/quantum/gfx/Texture.java
+++ b/src/main/java/quantum/gfx/Texture.java
@@ -30,11 +30,11 @@ import java.nio.IntBuffer;
 import java.util.Hashtable;
 
 import javax.imageio.ImageIO;
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.glu.GLU;
-import javax.media.opengl.glu.gl2.GLUgl2;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.glu.GLU;
+import com.jogamp.opengl.glu.gl2.GLUgl2;
 
 import quantum.utils.Log;
 

--- a/src/main/java/quantum/gfx/VertexArray.java
+++ b/src/main/java/quantum/gfx/VertexArray.java
@@ -13,9 +13,9 @@ package quantum.gfx;
 
 import java.nio.FloatBuffer;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
 
 import com.jogamp.common.nio.Buffers;
 

--- a/src/main/java/quantum/gui/Button.java
+++ b/src/main/java/quantum/gui/Button.java
@@ -13,7 +13,7 @@ package quantum.gui;
 
 import java.awt.event.KeyEvent;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 

--- a/src/main/java/quantum/gui/CheckBox.java
+++ b/src/main/java/quantum/gui/CheckBox.java
@@ -13,9 +13,9 @@ package quantum.gui;
 
 import java.awt.event.KeyEvent;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 

--- a/src/main/java/quantum/gui/ConfirmDialog.java
+++ b/src/main/java/quantum/gui/ConfirmDialog.java
@@ -11,7 +11,7 @@
 
 package quantum.gui;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 ;
 

--- a/src/main/java/quantum/gui/Container.java
+++ b/src/main/java/quantum/gui/Container.java
@@ -14,7 +14,7 @@ package quantum.gui;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class Container extends Widget {
 	private ArrayList<Widget> widgets = new ArrayList<Widget>();

--- a/src/main/java/quantum/gui/CustomDialog.java
+++ b/src/main/java/quantum/gui/CustomDialog.java
@@ -13,7 +13,7 @@ package quantum.gui;
 
 import java.util.ArrayList;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class CustomDialog extends ScreenAlignementContainer {
 	ArrayList<Button> buttons = new ArrayList<Button>();

--- a/src/main/java/quantum/gui/Gui.java
+++ b/src/main/java/quantum/gui/Gui.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Color;
 import quantum.gfx.Font;

--- a/src/main/java/quantum/gui/HorizontalBoxContainer.java
+++ b/src/main/java/quantum/gui/HorizontalBoxContainer.java
@@ -13,7 +13,7 @@ package quantum.gui;
 
 import java.util.LinkedList;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class HorizontalBoxContainer extends Container {
 	LinkedList<VerticalAlignement> v_aligns = new LinkedList<VerticalAlignement>();

--- a/src/main/java/quantum/gui/Image.java
+++ b/src/main/java/quantum/gui/Image.java
@@ -15,9 +15,9 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Texture;
 

--- a/src/main/java/quantum/gui/Label.java
+++ b/src/main/java/quantum/gui/Label.java
@@ -13,7 +13,7 @@ package quantum.gui;
 
 import java.util.ArrayList;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 

--- a/src/main/java/quantum/gui/List.java
+++ b/src/main/java/quantum/gui/List.java
@@ -13,9 +13,9 @@ package quantum.gui;
 
 import java.util.ArrayList;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 import quantum.utils.Timer;

--- a/src/main/java/quantum/gui/Slider.java
+++ b/src/main/java/quantum/gui/Slider.java
@@ -11,9 +11,9 @@
 
 package quantum.gui;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class Slider extends Widget {
 	float value = 0;

--- a/src/main/java/quantum/gui/Spacer.java
+++ b/src/main/java/quantum/gui/Spacer.java
@@ -11,7 +11,7 @@
 
 package quantum.gui;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class Spacer extends Widget {
 	boolean render = false;

--- a/src/main/java/quantum/gui/TextArea.java
+++ b/src/main/java/quantum/gui/TextArea.java
@@ -13,9 +13,9 @@ package quantum.gui;
 
 import java.util.ArrayList;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 import quantum.utils.Timer;

--- a/src/main/java/quantum/gui/TextField.java
+++ b/src/main/java/quantum/gui/TextField.java
@@ -11,8 +11,8 @@
 
 package quantum.gui;
 
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Font;
 import quantum.utils.Timer;

--- a/src/main/java/quantum/gui/VerticalBoxContainer.java
+++ b/src/main/java/quantum/gui/VerticalBoxContainer.java
@@ -13,7 +13,7 @@ package quantum.gui;
 
 import java.util.LinkedList;
 
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.awt.GLCanvas;
 
 public class VerticalBoxContainer extends Container {
 	LinkedList<HorizontalAlignement> h_aligns = new LinkedList<HorizontalAlignement>();

--- a/src/main/java/quantum/gui/Widget.java
+++ b/src/main/java/quantum/gui/Widget.java
@@ -11,10 +11,10 @@
 
 package quantum.gui;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLContext;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLContext;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.Color;
 import quantum.math.Vector2D;

--- a/src/main/java/quantum/gui/WorldAlignementContainer.java
+++ b/src/main/java/quantum/gui/WorldAlignementContainer.java
@@ -11,9 +11,9 @@
 
 package quantum.gui;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.awt.GLCanvas;
 
 import quantum.gfx.OrthoCamera;
 import quantum.math.Vector2D;

--- a/src/main/java/quantum/tests/BasicTest.java
+++ b/src/main/java/quantum/tests/BasicTest.java
@@ -15,12 +15,12 @@ import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GLAutoDrawable;
-import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLEventListener;
-import javax.media.opengl.GLProfile;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLCapabilities;
+import com.jogamp.opengl.GLEventListener;
+import com.jogamp.opengl.GLProfile;
+import com.jogamp.opengl.awt.GLCanvas;
 import javax.swing.JFrame;
 
 import quantum.game.Bot;

--- a/src/main/java/quantum/tests/GameReplay.java
+++ b/src/main/java/quantum/tests/GameReplay.java
@@ -21,13 +21,13 @@ import java.io.EOFException;
 import java.io.FileInputStream;
 import java.util.zip.GZIPInputStream;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLAutoDrawable;
-import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLEventListener;
-import javax.media.opengl.GLProfile;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLCapabilities;
+import com.jogamp.opengl.GLEventListener;
+import com.jogamp.opengl.GLProfile;
+import com.jogamp.opengl.awt.GLCanvas;
 import javax.swing.JFrame;
 
 import quantum.game.Constants;
@@ -178,7 +178,7 @@ public class GameReplay extends JFrame implements GLEventListener {
 			gui.render();
 
 			if (selected != null) {
-				ortho.setToOrtho2D(0, 0, canvas.getWidth(), canvas.getHeight());
+				ortho.setToOrtho2D(0, 0, canvas.getSurfaceWidth(), canvas.getSurfaceHeight());
 				gl.glLoadIdentity();
 				gl.glLoadMatrixf(ortho.toFloatBuffer());
 

--- a/src/main/java/quantum/tests/LocalTest.java
+++ b/src/main/java/quantum/tests/LocalTest.java
@@ -15,13 +15,13 @@ import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLAutoDrawable;
-import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLEventListener;
-import javax.media.opengl.GLProfile;
-import javax.media.opengl.awt.GLCanvas;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL2;
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLCapabilities;
+import com.jogamp.opengl.GLEventListener;
+import com.jogamp.opengl.GLProfile;
+import com.jogamp.opengl.awt.GLCanvas;
 import javax.swing.JFrame;
 
 import quantum.game.Creature;
@@ -102,7 +102,7 @@ public class LocalTest extends JFrame implements GLEventListener {
 		}
 		renderer.render(sim, (GLCanvas)arg0);
 
-		ortho.setToOrtho2D(0, 0, arg0.getWidth(), arg0.getHeight());
+		ortho.setToOrtho2D(0, 0, arg0.getSurfaceWidth(), arg0.getSurfaceHeight());
 		GL2 gl = arg0.getGL().getGL2();
 		gl.glMatrixMode(GL2.GL_PROJECTION);
 		gl.glLoadMatrixf(ortho.toFloatBuffer());
@@ -110,7 +110,7 @@ public class LocalTest extends JFrame implements GLEventListener {
 		gl.glLoadIdentity();
 		font.renderTextNewLine(
 			20,
-			arg0.getHeight() - 10,
+			arg0.getSurfaceHeight() - 10,
 			"fps: " + String.format("%.2f", renderer.getFramesPerSecond()) + "\n" + "simulation: "
 				+ String.format("%.2f", sim.getSimulationUpdateTime()) + " ms\n" + "rendering: "
 				+ String.format("%.2f", renderer.getRenderTime()) + " ms\n" + "trees: "


### PR DESCRIPTION
Rename import javax.media.opengl.\* -> import com.jogamp.opengl.\* across all files.
Rename GLCanvas getWidth -> getSurfaceWidth and getHeight -> getSurfaceHeight.
Replaced depricated com.jogamp.opengl.util.awt.Screenshot with com.jogamp.opengl.util.awt.AWTGLReadBufferUtil.
Use long type for shader objects.

Signed-off-by: Xerxes Rånby xerxes@gudinna.com
